### PR TITLE
Avoid C-isms

### DIFF
--- a/osc.lisp
+++ b/osc.lisp
@@ -291,22 +291,24 @@
 				    (ldb (byte 16 0) (decode-int32 s)))
   #-(or sbcl cmucl openmcl allegro) (error "cant decode floats using this implementation"))
 
-(defun decode-int32 (s)
-  "4 byte -> 32 bit int -> two's compliment (in network byte order)"
-  (let ((i (+ (ash (elt s 0) 24)
-	      (ash (elt s 1) 16)
-	      (ash (elt s 2) 8)
-	      (elt s 3))))
-    (if (>= i #x7fffffff)
-        (- 0 (- #x100000000 i))
-	i)))
-
 (defun decode-uint32 (s)
   "4 byte -> 32 bit unsigned int"
   (let ((i (+ (ash (elt s 0) 24)
 	      (ash (elt s 1) 16)
 	      (ash (elt s 2) 8)
 	      (elt s 3))))
+    i))
+
+(defun decode-uint64 (s)
+  "8 byte -> 64 bit unsigned int"
+  (let ((i (+ (ash (elt s 0) 56)
+	      (ash (elt s 1) 48)
+	      (ash (elt s 2) 40)
+	      (ash (elt s 3) 32)
+	      (ash (elt s 4) 24)
+	      (ash (elt s 5) 16)
+	      (ash (elt s 6) 8)
+	      (elt s 7))))
     i))
 
 (defmacro defint-encoder (num-of-octets &optional docstring)
@@ -327,28 +329,16 @@
 (defint-encoder 4 "Convert an integer into a sequence of 4 bytes in network byte order.")
 (defint-encoder 8 "Convert an integer into a sequence of 8 bytes in network byte order.")
 
-(defun decode-uint64 (s)
-  "8 byte -> 64 bit unsigned int"
-  (let ((i (+ (ash (elt s 0) 56)
-	      (ash (elt s 1) 48)
-	      (ash (elt s 2) 40)
-	      (ash (elt s 3) 32)
-	      (ash (elt s 4) 24)
-	      (ash (elt s 5) 16)
-	      (ash (elt s 6) 8)
-	      (elt s 7))))
-    i))
+(defun decode-int32 (s)
+  "4 byte -> 32 bit int -> two's complement (in network byte order)"
+  (let ((i (decode-uint32 s)))
+    (if (>= i #x7fffffff)
+        (- 0 (- #x100000000 i))
+	i)))
 
 (defun decode-int64 (s)
-  "8 byte -> 64 bit int -> two's compliment (in network byte order)"
-  (let ((i (+ (ash (elt s 0) 56)
-	      (ash (elt s 1) 48)
-	      (ash (elt s 2) 40)
-	      (ash (elt s 3) 32)
-	      (ash (elt s 4) 24)
-	      (ash (elt s 5) 16)
-	      (ash (elt s 6) 8)
-	      (elt s 7))))
+  "8 byte -> 64 bit int -> two's complement (in network byte order)"
+  (let ((i (decode-uint64 s)))
     (if (>= i #x7fffffffffffffff)
         (- 0 (- #x10000000000000000 i))
 	i)))

--- a/osc.lisp
+++ b/osc.lisp
@@ -309,37 +309,23 @@
 	      (elt s 3))))
     i))
 
-(defun encode-int32 (i)
-  "convert an integer into a sequence of 4 bytes in network byte order."
-  (declare (type integer i))
-  (let ((buf (make-sequence 
-	      '(vector (unsigned-byte 8)) 4)))
-    (macrolet ((set-byte (n)
-		 `(setf (elt buf ,n)
-			(logand #xff (ash i ,(* 8 (- n 3)))))))
-      (set-byte 0)
-      (set-byte 1)
-      (set-byte 2)
-      (set-byte 3))
-    buf))
+(defmacro defint-encoder (num-of-octets &optional docstring)
+  (let ((enc-name (intern (format nil "~:@(encode-int~)~D" (* 8 num-of-octets))))
+        (buf (gensym))
+        (int (gensym)))
+    `(defun ,enc-name (,int)
+       ,@(when docstring
+           (list docstring))
+       (let ((,buf (make-array ,num-of-octets :element-type '(unsigned-byte 8))))
+         ,@(loop
+             for n below num-of-octets
+             collect `(setf (aref ,buf ,n)
+                            (ldb (byte 8 (* 8 (- (1- ,num-of-octets) ,n)))
+                                 ,int)))
+         ,buf))))
 
-(defun encode-int64 (i)
-  "convert an integer into a sequence of 8 bytes in network byte order."
-  (declare (type integer i))
-  (let ((buf (make-sequence
-	      '(vector (unsigned-byte 8)) 8)))
-    (macrolet ((set-byte (n)
-		 `(setf (elt buf ,n)
-			(logand #xff (ash i ,(* 8 (- n 7)))))))
-      (set-byte 0)
-      (set-byte 1)
-      (set-byte 2)
-      (set-byte 3)
-      (set-byte 4)
-      (set-byte 5)
-      (set-byte 6)
-      (set-byte 7))
-    buf))
+(defint-encoder 4 "Convert an integer into a sequence of 4 bytes in network byte order.")
+(defint-encoder 8 "Convert an integer into a sequence of 8 bytes in network byte order.")
 
 (defun decode-uint64 (s)
   "8 byte -> 64 bit unsigned int"

--- a/osc.lisp
+++ b/osc.lisp
@@ -329,15 +329,15 @@
 (defun decode-int32 (s)
   "4 byte -> 32 bit int -> two's complement (in network byte order)"
   (let ((i (decode-uint32 s)))
-    (if (>= i #x7fffffff)
-        (- 0 (- #x100000000 i))
+    (if (>= i #.(1- (expt 2 31)))
+        (- (- #.(expt 2 32) i))
 	i)))
 
 (defun decode-int64 (s)
   "8 byte -> 64 bit int -> two's complement (in network byte order)"
   (let ((i (decode-uint64 s)))
-    (if (>= i #x7fffffffffffffff)
-        (- 0 (- #x10000000000000000 i))
+    (if (>= i #.(1- (expt 2 63)))
+        (- (- #.(expt 2 64) i))
 	i)))
 
 ;; osc-strings are unsigned bytes, padded to a 4 byte boundary 


### PR DESCRIPTION
Using `ldb/dpb` instead of shifting bits and adding 'numbers' is not only more direct but also generates more efficient code in SBCL. This is not the case in all implementations. For example ECL will still compile to code that does more or less the name (ash + ecl_boole). I also refactored common code so that we only need to specify the number of octets to decode or decode and the decoder is derived for us as well as leaving some constants 'unfolded' so that their meaning is more apparent but moving the computation to read-time so the resulting code stays the same.