### PR TITLE
Fix DEFINT-DECODER

### DIFF
--- a/osc.lisp
+++ b/osc.lisp
@@ -303,7 +303,7 @@
                   for n below num-of-octets
                   collect `(,int (dpb (aref ,seq ,n) (byte 8 (* 8 (- (1- ,num-of-octets) ,n)))
                                       ,int))))
-         int))))
+         ,int))))
 
 (defint-decoder 4 "4 byte -> 32 bit unsigned int")
 (defint-decoder 8 "8 byte -> 64 bit unsigned int")


### PR DESCRIPTION
Hey sorry it appears I introduced a bug in the previous PR. I forgot to unquote the GENSYMed symbol. :shame:. This should fix it.